### PR TITLE
Make ShuffleBuf generic over buffer size using const generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ communications drivers using something like this.
 
 - [x] Works
 - [x] Tests
-- [ ] Generic over buffer length (currently fixed length buffer)
+- [x] Generic over buffer length (currently fixed length buffer)
 - [ ] Theoretically Awesome

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,4 +258,17 @@ mod tests {
         let read_count = shuffler.read_many(&mut buf_b);
         assert_eq!(read_count, 0);
     }
+
+    #[test]
+    fn test_read_one() {
+        let buf_a: [u8; 10] = [7, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+        let mut shuffler = ShuffleBuf::<64>::default();
+        let push_count = shuffler.push_many(&buf_a);
+        assert_eq!(push_count, buf_a.len());
+
+        let (read_count, data) = shuffler.read_one();
+        assert_eq!(read_count, 1);
+        assert_eq!(data, 7);
+    }
 }


### PR DESCRIPTION
Hi :)

I saw that in your ublox-m8 driver, shufflebuf is used, but it is not found on crates.io. So I found this crate here.
As I have done a sort of similar small ringbuffer project (https://github.com/barafael/rbf-rs), I decided to implement one point from your readme as it might be useful to me too.

The failing test of course still fails. What is the purpose? It's using `unsafe` in an unsafe way.

Along the way, I fixed one clippy lint and ran Rustfmt.

Please let me know what you think :)

Rafael